### PR TITLE
Fail the action if curl doesn't download anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ deploy-code:
 
     steps:
       - name: Download artifacts from release
-        uses: im-open/download-release-asset@v1.0.0
+        uses: im-open/download-release-asset@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           asset-name: ${{ env.ASSET_ZIP }}

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         GH_TAGS="$GH_REPO/releases/tags/${{ inputs.tag-name }}"
         AUTH="Authorization: token ${{ inputs.github-token }}"
         WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
-        CURL_ARGS="-LJO#"
+        CURL_ARGS="-LJO#f"
 
         # Read asset tags.
         response=$(curl -sH "$AUTH" $GH_TAGS)


### PR DESCRIPTION
If curl is unable to download the file, `-f` should cause it to produce a non-zero exit code, causing the script to exit with a non-zero code so the action fails.
See https://www.mit.edu/afs.new/sipb/user/ssen/src/curl-7.11.1/docs/curl.html#-f--fail