### PR TITLE
Add ability to download from a different repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This action can be used to download an asset from a GitHub release.  The GitHub 
 
 ## Inputs
 
-| Parameter      | Is Required | Default | Description                                                             |
-| -------------- | ----------- |         | ----------------------------------------------------------------------- |
-| `github-token` | true        |         | A token with permission to download assets from repository releases. Provide your own PAT with permissions to your repository if a different org/repo is provided. |
-| `asset-name`   | true        |         | The name of the release asset.                                           |
-| `tag-name`     | true        |         | The tag associated with the release that contains the asset to download. You may also use the tag name "latest". |
-| `repository`   | false       | `github.repository` | organization/repository. If not provided, defaults to the repo where the action is being used. |
+| Parameter      | Is Required | Default                                                                             | Description                                                                                                                                                                                                                                                                       |
+| -------------- | ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `github-token` | true        | N/A                                                                                 | A token with permission to download assets from repository releases. When downloading from the repository the action is running in `secrets.GITHUB_TOKEN` is sufficient.  If downloading from a separate repo, a different token with permission to that repo should be provided. |
+| `asset-name`   | true        | N/A                                                                                 | The name of the release asset.                                                                                                                                                                                                                                                    |
+| `tag-name`     | true        | N/A                                                                                 | The tag associated with the release that contains the asset to download. You may also use the tag name `latest`.                                                                                                                                                                  |
+| `repository`   | false       | `github.repository`<br/> <i>The organization/repository where the action is run</i> | The organization/repository to download the release asset from.                                                                                                                                                                                                                   |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ deploy-code:
 
     steps:
       - name: Download artifacts from release
-        uses: im-open/download-release-asset@v1.0.2
+        uses: im-open/download-release-asset@v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           asset-name: ${{ env.ASSET_ZIP }}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ This action can be used to download an asset from a GitHub release.  The GitHub 
 
 ## Inputs
 
-| Parameter      | Is Required | Description                                                             |
-| -------------- | ----------- | ----------------------------------------------------------------------- |
-| `github-token` | true        | A token with permission to download assets from repository releases     |
-| `asset-name`   | true        | The name of the release asset                                           |
-| `tag-name`     | true        | The tag associated with the release that contains the asset to download |
+| Parameter      | Is Required | Default | Description                                                             |
+| -------------- | ----------- |         | ----------------------------------------------------------------------- |
+| `github-token` | true        |         | A token with permission to download assets from repository releases. Provide your own PAT with permissions to your repository if a different org/repo is provided. |
+| `asset-name`   | true        |         | The name of the release asset.                                           |
+| `tag-name`     | true        |         | The tag associated with the release that contains the asset to download. You may also use the tag name "latest". |
+| `repository`   | false       | `github.repository` | organization/repository. If not provided, defaults to the repo where the action is being used. |
 
 ## Outputs
 
@@ -45,9 +46,17 @@ deploy-code:
       - name: Unzip release asset
         run: unzip -qq ${{ env.ASSET_ZIP }} -d ./${{ env.UNZIPPED_ASSET }}
 
+      # ----
+      - name: Download artifacts from latest release in a different repo
+        uses: im-open/download-release-asset@v1.1.0
+        with:
+          github-token: ${{ secrets.PERSONAL_PAT }} # GitHub PAT that has permissions to the org/repo
+          asset-name: ${{ env.ASSET_ZIP }}
+          tag-name: latest
+          repository: im-enrollment/repo-with-release
+
      ...
 ```
-
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: 'The tag associated with the release that contains the asset to download. You may also use the tag name "latest".'
     required: true
   repository:
-    description: 'organization/repository. If not provided, defaults to github.repository'
+    description: 'The organization/repository to download the release asset from.  If not provided, defaults to github.repository'
     required: false
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   tag-name:
     description: 'The tag associated with the release that contains the asset to download'
     required: true
+  repository:
+    description: 'If not provided, defaults to the repo where the action is being used'
+    required: false
 
 runs:
   using: 'composite'
@@ -24,8 +27,8 @@ runs:
 
         # Define variables.
         name='${{ inputs.asset-name }}'
-        GH_REPO="https://api.github.com/repos/${{ github.repository }}"
-        GH_TAGS="$GH_REPO/releases/tags/${{ inputs.tag-name }}"
+        GH_REPO="https://api.github.com/repos/${{ inputs.repository || github.repository }}"
+        GH_TAGS="$GH_REPO/releases/${{ (inputs.tag-name == 'latest' && 'latest') || format('tags/{0}', inputs.tag-name) }}"
         AUTH="Authorization: token ${{ inputs.github-token }}"
         WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
         CURL_ARGS="-LJO#f"

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,10 @@ inputs:
     description: 'The name of the release asset'
     required: true
   tag-name:
-    description: 'The tag associated with the release that contains the asset to download'
+    description: 'The tag associated with the release that contains the asset to download. You may also use the tag name "latest".'
     required: true
   repository:
-    description: 'If not provided, defaults to the repo where the action is being used'
+    description: 'organization/repository. If not provided, defaults to github.repository'
     required: false
 
 runs:


### PR DESCRIPTION
# Summary of PR changes
I have a use case where I want to utilize assets from another repo.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
