### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ deploy-code:
 
     steps:
       - name: Download artifacts from release
-        uses: im-open/download-release-asset@v1.1.2
+        uses: im-open/download-release-asset@v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           asset-name: ${{ env.ASSET_ZIP }}
@@ -50,7 +50,7 @@ deploy-code:
 
       # ----
       - name: Download artifacts from latest release in a different repo
-        uses: im-open/download-release-asset@v1.1.2
+        uses: im-open/download-release-asset@v1.2.0
         with:
           github-token: ${{ secrets.PERSONAL_PAT }} # GitHub PAT that has permissions to the org/repo
           asset-name: ${{ env.ASSET_ZIP }}

--- a/action.yml
+++ b/action.yml
@@ -53,4 +53,4 @@ runs:
 
         base_path=$(pwd)
         download_file_path="$base_path/${{ inputs.asset-name }}"
-        echo "::set-output name=download_file_path::$download_file_path"
+        echo "download_file_path=$download_file_path" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
